### PR TITLE
Add documentation to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/html/

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rdoc/task'
 
 RSpec::Core::RakeTask.new(:spec)
+
+RDoc::Task.new do |doc|
+  doc.main   = 'README.md'
+  doc.title  = 'Freakin'
+  doc.rdoc_files = FileList.new %w[README.md lib LICENSE.txt]
+end
 
 task :default => :spec

--- a/freakin.gemspec
+++ b/freakin.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rdoc', '~> 4.2'
 end

--- a/lib/freakin.rb
+++ b/lib/freakin.rb
@@ -1,9 +1,22 @@
 require 'freakin/version'
 require 'freakin/translator'
 
-module Freakin
-  # Your code goes here...
+module Freakin #:nodoc:
+  # The main Freakin class. It is not intended to be instantiated and instead
+  # just need to call its hi method.
   class Freakin
+    # When called returns a greeting matching the language defined. Currently
+    # supports English and Spanish.
+    #
+    # ==== Attributes
+    #
+    # * +language+ - Set to select a different language. Default is +english+.
+    #
+    # ==== Examples
+    #
+    #   Freakin::Freakin.hi
+    #   Freakin::Freakin.hi('spanish')
+    #
     def self.hi(language = 'english')
       trans = Translator.new(language)
       trans.hi

--- a/lib/freakin/translator.rb
+++ b/lib/freakin/translator.rb
@@ -1,10 +1,23 @@
-module Freakin
-  # Translator class
+module Freakin #:nodoc:
+  # An instance of +Translator+ will determine what greeting to return based
+  # on the language selected when its instantiated
   class Translator
+    # Instantiate a new instance of Translator for a chosen language
+    #
+    # ==== Examples
+    #
+    #   Freakin::Translator.new('spanish')
+    #
     def initialize(language)
       @language = language
     end
 
+    # Call to return a greeting
+    # ==== Examples
+    #
+    #   foo = Freakin::Translator.new('spanish')
+    #   foo.hi # 'hola mundo'
+    #
     def hi
       case @language
       when 'spanish'

--- a/lib/freakin/version.rb
+++ b/lib/freakin/version.rb
@@ -1,3 +1,3 @@
-module Freakin
-  VERSION = "0.1.0"
+module Freakin #:nodoc:
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
This change adds support for documentation to the project. Not only have we documented our classes and methods, we're also added a dev dependency on 'rdoc' and support for Rake tasks to generate (and regenerate) documentation.
